### PR TITLE
reverse lat/lon values coming back from the API

### DIFF
--- a/lib/arcgis_geocode.ex
+++ b/lib/arcgis_geocode.ex
@@ -40,7 +40,7 @@ defmodule ArcgisGeocode do
         {:ok,
          %ArcgisGeocode.GeocodeResult{city: "Colchester",
          formatted: "463 Mountain View Dr, Colchester, Vermont, 05446",
-         lat: -73.18369670074134, lon: 44.51295979206185, state_abbr: "VT",
+         lat: 44.51295979206185, lon: -73.18369670074134, state_abbr: "VT",
          state_name: "Vermont", street_name: "Mountain View", street_number: "463",
          street_type: "Dr", zip_code: "05446"}}
 

--- a/lib/arcgis_geocode/geocoder.ex
+++ b/lib/arcgis_geocode/geocoder.ex
@@ -44,8 +44,8 @@ defmodule ArcgisGeocode.Geocoder do
     attributes = feature["attributes"]
     {:ok,
       %GeocodeResult{
-        lat: feature["geometry"]["x"],
-        lon: feature["geometry"]["y"],
+        lat: feature["geometry"]["y"],
+        lon: feature["geometry"]["x"],
         street_number: attributes["AddNum"],
         street_name: attributes["StName"],
         street_type: attributes["StType"],

--- a/test/arcgis_geocode/geocoder_test.exs
+++ b/test/arcgis_geocode/geocoder_test.exs
@@ -13,7 +13,7 @@ defmodule GeocoderTest do
     geocoded = Geocoder.geocode("463 Mountain View Dr Colchester VT 05446")
     assert geocoded == {:ok, %GeocodeResult{
                               city: "Colchester", formatted: "463 Mountain View Dr, Colchester, Vermont, 05446",
-                              lat: -73.18369670074134, lon: 44.51295979206185, state_name: "Vermont", state_abbr: "VT",
+                              lat: 44.51295979206185, lon: -73.18369670074134, state_name: "Vermont", state_abbr: "VT",
                               street_name: "Mountain View", street_type: "Dr", street_number: "463", zip_code: "05446"}}
 
   end


### PR DESCRIPTION
Reverses the properties in which lat/lon values are stored in the GeocodeResult.
